### PR TITLE
Remove the unnecessary sudo call from the tool

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func validMAC(input string, devices map[string]Device) bool {
 }
 
 func runBluetoothctl(command string) string {
-	cmd := exec.Command("bash", "-c", fmt.Sprintf("echo -e \"%s\" | sudo bluetoothctl", command))
+	cmd := exec.Command("bash", "-c", fmt.Sprintf("echo -e \"%s\" | bluetoothctl", command))
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err := cmd.Run()


### PR DESCRIPTION
remove sudo from bluetoothctl call

it should be handled through some other means, not by this tool in general