### PR TITLE
modernize stdlib usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/qikiqi/go-rofi-bluetooth-menu
 
-go 1.23.1
+go 1.25.0

--- a/internal/program/devices.go
+++ b/internal/program/devices.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -68,8 +68,15 @@ func sortByConnected(devices map[string]Device) []Device {
 	for _, d := range devices {
 		list = append(list, d)
 	}
-	sort.Slice(list, func(i, j int) bool {
-		return list[i].Connected && !list[j].Connected
+	slices.SortFunc(list, func(a, b Device) int {
+		switch {
+		case a.Connected == b.Connected:
+			return 0
+		case a.Connected:
+			return -1
+		default:
+			return 1
+		}
 	})
 	return list
 }

--- a/internal/program/exec_test.go
+++ b/internal/program/exec_test.go
@@ -1,7 +1,6 @@
 package program
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -36,7 +35,7 @@ func stubExecutable(t *testing.T, name, scriptBody string) string {
 func TestRunBluetoothctl(t *testing.T) {
 	stubExecutable(t, "bluetoothctl", "cat")
 
-	got, err := bluetoothctlRunner{}.Run(context.Background(), "devices")
+	got, err := bluetoothctlRunner{}.Run(t.Context(), "devices")
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
@@ -50,7 +49,7 @@ func TestRunBluetoothctl_MissingBinary(t *testing.T) {
 	// Run logs the error and returns empty output.
 	t.Setenv("PATH", t.TempDir())
 
-	got, err := bluetoothctlRunner{}.Run(context.Background(), "devices")
+	got, err := bluetoothctlRunner{}.Run(t.Context(), "devices")
 	if err == nil {
 		t.Error("Run() error = nil, want an error when bluetoothctl is missing")
 	}
@@ -70,7 +69,7 @@ echo "selected line"`, argsFile)
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	tempFileName := filepath.Join(dir, "menu-input")
-	got, err := rofiMenu{}.Prompt(context.Background(), tempFileName)
+	got, err := rofiMenu{}.Prompt(t.Context(), tempFileName)
 	if err != nil {
 		t.Fatalf("Prompt() error = %v", err)
 	}
@@ -92,7 +91,7 @@ func TestConnectDevice(t *testing.T) {
 	logFile := filepath.Join(dir, "invocations.log")
 	stubExecutable(t, "bluetoothctl", fmt.Sprintf("cat >> %q", logFile))
 
-	if err := connectDevice(context.Background(), bluetoothctlRunner{}, Device{MAC: "AA:BB:CC:DD:EE:FF", Connected: true}); err != nil {
+	if err := connectDevice(t.Context(), bluetoothctlRunner{}, Device{MAC: "AA:BB:CC:DD:EE:FF", Connected: true}); err != nil {
 		t.Fatalf("connectDevice() error = %v", err)
 	}
 

--- a/internal/program/program_test.go
+++ b/internal/program/program_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"maps"
 	"os"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -95,7 +96,7 @@ func TestParseDevices(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := parseDevices(tt.input)
-			if !reflect.DeepEqual(got, tt.want) {
+			if !slices.Equal(got, tt.want) {
 				t.Errorf("parseDevices(%q) = %#v, want %#v", tt.input, got, tt.want)
 			}
 		})
@@ -215,10 +216,10 @@ func TestSelectionIssuesConnectCommand(t *testing.T) {
 				t.Fatalf("resolveSelection(%q) error = %v", tt.selection, err)
 			}
 			bt := &fakeBluetoothctl{}
-			if err := connectDevice(context.Background(), bt, device); err != nil {
+			if err := connectDevice(t.Context(), bt, device); err != nil {
 				t.Fatalf("connectDevice() error = %v", err)
 			}
-			if !reflect.DeepEqual(bt.commands, tt.wantCmds) {
+			if !slices.Equal(bt.commands, tt.wantCmds) {
 				t.Errorf("connectDevice issued %v, want %v", bt.commands, tt.wantCmds)
 			}
 		})
@@ -339,7 +340,7 @@ func TestMergeDevices(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := mergeDevices(tt.connected, tt.paired)
-			if !reflect.DeepEqual(got, tt.want) {
+			if !maps.Equal(got, tt.want) {
 				t.Errorf("mergeDevices(%v, %v) = %+v, want %+v", tt.connected, tt.paired, got, tt.want)
 			}
 		})


### PR DESCRIPTION
### What
<!-- gpr:mode=short -->
- chore: bump go directive to 1.25: 613a015
- refactor: replace sort.Slice with slices.SortFunc: 0790566
- test: modernize tests with t.Context() and slices/maps equality: 287eb33

